### PR TITLE
feat: add UrlSafeBase64 and isNode

### DIFF
--- a/src/utilities/env.jsdom.test.ts
+++ b/src/utilities/env.jsdom.test.ts
@@ -1,0 +1,8 @@
+/** @jest-environment jsdom */
+import { isNode } from './env';
+
+describe('isNode()', () => {
+  it('when running under non-Node', () => {
+    expect(isNode()).toBeFalsy();
+  });
+});

--- a/src/utilities/env.test.ts
+++ b/src/utilities/env.test.ts
@@ -1,4 +1,4 @@
-import { assertEnv, getEnv } from './env';
+import { assertEnv, getEnv, isNode } from './env';
 
 describe('getEnv()', () => {
   beforeAll(() => {
@@ -25,5 +25,11 @@ describe('assertEnv()', () => {
 
   it("throws an error if env doesn't exist", () => {
     expect(() => assertEnv('BAR')).toThrow('env variable BAR not found');
+  });
+});
+
+describe('isNode()', () => {
+  it('when running under Node', () => {
+    expect(isNode()).toBeTruthy();
   });
 });

--- a/src/utilities/env.ts
+++ b/src/utilities/env.ts
@@ -6,3 +6,5 @@ export const assertEnv = (key: string): string => {
   assert(value, new Error(`env variable ${key} not found`));
   return value;
 };
+
+export const isNode = () => typeof window === 'undefined';

--- a/src/utilities/string.test.ts
+++ b/src/utilities/string.test.ts
@@ -1,0 +1,46 @@
+import { toTitle, UrlSafeBase64 } from './string';
+
+describe('toTitle()', () => {
+  test('upper-case the first non-blank character of each word', () => {
+    expect(toTitle('normal title')).toEqual('Normal Title');
+  });
+
+  test('remove `-` characters in the string', () => {
+    expect(toTitle('String-Contains-Minus-Signs')).toEqual('String Contains Minus Signs');
+  });
+});
+
+describe('UrlSafeBase64()', () => {
+  const RAW_CONTENT = 'J)oz¸Z\u009Dß¢£ùh\u0082Ú';
+  const URL_SAFE_ENCODED_CONTENT = 'Silverhand-io_logto';
+
+  describe('encode()', () => {
+    test('replace plus sign `+` (by minus sign `-`) and slash `/` (by underscore `_`) in base64-encoded content', () => {
+      expect(UrlSafeBase64.encode(RAW_CONTENT)).toEqual(URL_SAFE_ENCODED_CONTENT);
+    });
+  });
+
+  describe('decode()', () => {
+    test('restore plus sign `+` (by minus sign `-`) and slash `/` (by underscore `_`) in base64-encoded content', () => {
+      expect(UrlSafeBase64.decode(URL_SAFE_ENCODED_CONTENT)).toEqual(RAW_CONTENT);
+    });
+  });
+
+  const ENCODED_CONTENT = 'Silverhand+io/logto';
+
+  describe('replaceNonUrlSafeCharacters()', () => {
+    test('replaceNonUrlSafeCharacters and remove non-url-safe character `=`', () => {
+      expect(UrlSafeBase64.replaceNonUrlSafeCharacters(`${ENCODED_CONTENT}=`)).toEqual(
+        URL_SAFE_ENCODED_CONTENT
+      );
+    });
+  });
+
+  describe('restoreNonUrlSafeCharacters()', () => {
+    test('restoreNonUrlSafeCharacters', () => {
+      expect(UrlSafeBase64.restoreNonUrlSafeCharacters(URL_SAFE_ENCODED_CONTENT)).toEqual(
+        ENCODED_CONTENT
+      );
+    });
+  });
+});

--- a/src/utilities/string.ts
+++ b/src/utilities/string.ts
@@ -1,3 +1,5 @@
+import { isNode } from './env';
+
 export function toTitle(string: string) {
   if (typeof string !== 'string') {
     throw new TypeError('Expected a string');
@@ -8,3 +10,37 @@ export function toTitle(string: string) {
     .replace(/(?:^|\s|-)\S/g, (x) => x.toUpperCase())
     .replace(/-/g, ' ');
 }
+
+/**
+ * RFC 4648 section 5: base64url (URL- and filename-safe standard)
+ * @link https://datatracker.ietf.org/doc/html/rfc4648#section-5
+ */
+const replaceNonUrlSafeCharacters = (base64String: string) =>
+  base64String.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+const restoreNonUrlSafeCharacters = (base64String: string) =>
+  base64String.replace(/-/g, '+').replace(/_/g, '/');
+
+/**
+ * The method `btoa`/`atob` can only encode/decode the characters inside of the Latin1 range.
+ * Force Node `buffer` to use Latin1 character set so that its encoded/decoded result is as same as `btoa`/`atob`.
+ * It's guaranteed that the behaviors of `UrlSafeBase64.encode` and `UrlSafeBase64.decode` are the same under both Node and browser-like environments.
+ * `UrlSafeBase64` below is enough for current use cases, e.g.: for random ascii (within Latin1 range) string generators.
+ */
+const CHARACTER_SET_OF_BTOA_ATOB = 'latin1';
+
+export const UrlSafeBase64 = {
+  encode: (rawString: string) => {
+    const encodedString = isNode()
+      ? Buffer.from(rawString, CHARACTER_SET_OF_BTOA_ATOB).toString('base64')
+      : btoa(rawString);
+    return replaceNonUrlSafeCharacters(encodedString);
+  },
+  decode: (encodedString: string) => {
+    const nonUrlSafeEncodedString = restoreNonUrlSafeCharacters(encodedString);
+    return isNode()
+      ? Buffer.from(nonUrlSafeEncodedString, 'base64').toString(CHARACTER_SET_OF_BTOA_ATOB)
+      : atob(nonUrlSafeEncodedString);
+  },
+  replaceNonUrlSafeCharacters,
+  restoreNonUrlSafeCharacters,
+};


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- Move `UrlSafeBase64` from `log-to/js/utils.ts` to `silverhand-io/essentials/string.ts`
- Add `isNode` for checking whether it is running under Node (or Web Browser)

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- UrlSafeBase64.encode(rawContent) === expectedEncodedContent
- UrlSafeBase64.decode(encodedContent) === expectedRawContent
- replaceNonUrlSafeCharacters(nonUrlSafeCharacters) === expectedCharacterSubstitutes
- restoreNonUrlSafeCharacters(characterSubstitutes) === expectedNonUrlSafeCharacters
