### PR TITLE
feat: add UrlSafeBase64.isSafe

### DIFF
--- a/src/utilities/string.test.ts
+++ b/src/utilities/string.test.ts
@@ -43,4 +43,20 @@ describe('UrlSafeBase64()', () => {
       );
     });
   });
+
+  describe('isSafe()', () => {
+    test('empty string should be true', () => {
+      expect(UrlSafeBase64.isSafe('')).toBeTruthy();
+    });
+
+    test('url-safe characters should be true', () => {
+      expect(
+        UrlSafeBase64.isSafe('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_')
+      ).toBeTruthy();
+    });
+
+    test('non-url-safe characters should be false', () => {
+      expect(UrlSafeBase64.isSafe('=+')).toBeFalsy();
+    });
+  });
 });

--- a/src/utilities/string.ts
+++ b/src/utilities/string.ts
@@ -29,6 +29,7 @@ const restoreNonUrlSafeCharacters = (base64String: string) =>
 const CHARACTER_SET_OF_BTOA_ATOB = 'latin1';
 
 export const UrlSafeBase64 = {
+  isSafe: (input: string) => /^[\w-]*$/.test(input),
   encode: (rawString: string) => {
     const encodedString = isNode()
       ? Buffer.from(rawString, CHARACTER_SET_OF_BTOA_ATOB).toString('base64')


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Add UrlSafeBase64.isSafe

Definition of **safe**: both url-safe and base64

- `a-z A-Z 0-9 _ -`

Reference:

- [Which special characters are safe to use in url? - StackExchange ProWebMasters](https://webmasters.stackexchange.com/questions/498/which-special-characters-are-safe-to-use-in-url)
    - more **url-safe**: both url-safe and base64 `a-z A-Z 0-9 _ -`
- [What are the safe characters for making URLs? - StackOverflow](https://stackoverflow.com/questions/695438/what-are-the-safe-characters-for-making-urls)
    - normal url-safe:  `a-z A-Z 0-9 _ - . ~`

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1378

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- empty string → true
- safe string → true
- unsafe string → false

---
@simeng-li @wangsijie @xiaoyijun @gao-sun @darcyYe 
(PS: We also need to able to use `@eng` to mention all team members in silverhand-io. How to enable it?)