### PR TITLE
fix: encode and decode base64 string with utf-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cache
 .DS_Store
 *.env
 .idea/
+.history

--- a/src/utilities/string.test.ts
+++ b/src/utilities/string.test.ts
@@ -1,4 +1,4 @@
-import { toTitle, UrlSafeBase64 } from './string';
+import { toTitle, urlSafeBase64 } from './string';
 
 describe('toTitle()', () => {
   test('upper-case the first non-blank character of each word', () => {
@@ -11,26 +11,27 @@ describe('toTitle()', () => {
 });
 
 describe('UrlSafeBase64()', () => {
-  const RAW_CONTENT = 'J)oz¸Z\u009Dß¢£ùh\u0082Ú';
-  const URL_SAFE_ENCODED_CONTENT = 'Silverhand-io_logto';
+  const RAW_CONTENT = 'subjects?d=1subjects>d=1{"alg":"RS256","name":"测试"}';
+  const ENCODED_CONTENT =
+    'c3ViamVjdHM/ZD0xc3ViamVjdHM+ZD0xeyJhbGciOiJSUzI1NiIsIm5hbWUiOiLmtYvor5UifQ==';
+  const URL_SAFE_ENCODED_CONTENT =
+    'c3ViamVjdHM_ZD0xc3ViamVjdHM-ZD0xeyJhbGciOiJSUzI1NiIsIm5hbWUiOiLmtYvor5UifQ';
 
   describe('encode()', () => {
     test('replace plus sign `+` (by minus sign `-`) and slash `/` (by underscore `_`) in base64-encoded content', () => {
-      expect(UrlSafeBase64.encode(RAW_CONTENT)).toEqual(URL_SAFE_ENCODED_CONTENT);
+      expect(urlSafeBase64.encode(RAW_CONTENT)).toEqual(URL_SAFE_ENCODED_CONTENT);
     });
   });
 
   describe('decode()', () => {
     test('restore plus sign `+` (by minus sign `-`) and slash `/` (by underscore `_`) in base64-encoded content', () => {
-      expect(UrlSafeBase64.decode(URL_SAFE_ENCODED_CONTENT)).toEqual(RAW_CONTENT);
+      expect(urlSafeBase64.decode(URL_SAFE_ENCODED_CONTENT)).toEqual(RAW_CONTENT);
     });
   });
 
-  const ENCODED_CONTENT = 'Silverhand+io/logto';
-
   describe('replaceNonUrlSafeCharacters()', () => {
     test('replaceNonUrlSafeCharacters and remove non-url-safe character `=`', () => {
-      expect(UrlSafeBase64.replaceNonUrlSafeCharacters(`${ENCODED_CONTENT}=`)).toEqual(
+      expect(urlSafeBase64.replaceNonUrlSafeCharacters(ENCODED_CONTENT)).toEqual(
         URL_SAFE_ENCODED_CONTENT
       );
     });
@@ -38,7 +39,7 @@ describe('UrlSafeBase64()', () => {
 
   describe('restoreNonUrlSafeCharacters()', () => {
     test('restoreNonUrlSafeCharacters', () => {
-      expect(UrlSafeBase64.restoreNonUrlSafeCharacters(URL_SAFE_ENCODED_CONTENT)).toEqual(
+      expect(urlSafeBase64.restoreNonUrlSafeCharacters(`${URL_SAFE_ENCODED_CONTENT}==`)).toEqual(
         ENCODED_CONTENT
       );
     });
@@ -46,17 +47,17 @@ describe('UrlSafeBase64()', () => {
 
   describe('isSafe()', () => {
     test('empty string should be true', () => {
-      expect(UrlSafeBase64.isSafe('')).toBeTruthy();
+      expect(urlSafeBase64.isSafe('')).toBeTruthy();
     });
 
     test('url-safe characters should be true', () => {
       expect(
-        UrlSafeBase64.isSafe('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_')
+        urlSafeBase64.isSafe('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_')
       ).toBeTruthy();
     });
 
     test('non-url-safe characters should be false', () => {
-      expect(UrlSafeBase64.isSafe('=+')).toBeFalsy();
+      expect(urlSafeBase64.isSafe('=+')).toBeFalsy();
     });
   });
 });

--- a/src/utilities/string.ts
+++ b/src/utilities/string.ts
@@ -20,20 +20,12 @@ const replaceNonUrlSafeCharacters = (base64String: string) =>
 const restoreNonUrlSafeCharacters = (base64String: string) =>
   base64String.replace(/-/g, '+').replace(/_/g, '/');
 
-/**
- * The method `btoa`/`atob` can only encode/decode the characters inside of the Latin1 range.
- * Force Node `buffer` to use Latin1 character set so that its encoded/decoded result is as same as `btoa`/`atob`.
- * It's guaranteed that the behaviors of `UrlSafeBase64.encode` and `UrlSafeBase64.decode` are the same under both Node and browser-like environments.
- * `UrlSafeBase64` below is enough for current use cases, e.g.: for random ascii (within Latin1 range) string generators.
- */
-const CHARACTER_SET_OF_BTOA_ATOB = 'latin1';
-
-export const UrlSafeBase64 = {
+export const urlSafeBase64 = {
   isSafe: (input: string) => /^[\w-]*$/.test(input),
   encode: (rawString: string) => {
     const encodedString = isNode()
-      ? Buffer.from(rawString, CHARACTER_SET_OF_BTOA_ATOB).toString('base64')
-      : btoa(rawString);
+      ? Buffer.from(rawString, 'utf8').toString('base64')
+      : window.btoa(unescape(encodeURIComponent(rawString)));
 
     return replaceNonUrlSafeCharacters(encodedString);
   },
@@ -41,8 +33,8 @@ export const UrlSafeBase64 = {
     const nonUrlSafeEncodedString = restoreNonUrlSafeCharacters(encodedString);
 
     return isNode()
-      ? Buffer.from(nonUrlSafeEncodedString, 'base64').toString(CHARACTER_SET_OF_BTOA_ATOB)
-      : atob(nonUrlSafeEncodedString);
+      ? Buffer.from(nonUrlSafeEncodedString, 'base64').toString('utf8')
+      : decodeURIComponent(escape(window.atob(nonUrlSafeEncodedString)));
   },
   replaceNonUrlSafeCharacters,
   restoreNonUrlSafeCharacters,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Encode and decode base64 string with UTF-8 character set, in order to avoid ending up with garbled text when using CJK characters.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-4198](https://linear.app/silverhand/issue/LOG-4198/decode-idtoken-containing-cjk-ended-up-with-garbled-text)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Test cases modified to support Chinese and passed successfully