### PR TITLE
chore: make default exports condition to last

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "main": "lib/index.js",
   "module": "lib/index.js",
   "exports": {
-    "default": "./lib/index.js",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "default": "./lib/index.js"
   },
   "files": [
     "lib"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
When using NextJS, an error will happen:
```
@logto/next-sample: info  - Creating an optimized production build...
@logto/next-sample: Failed to compile.
@logto/next-sample: ../js/lib/module.mjs
@logto/next-sample: Module not found: Default condition should be last one
@logto/next-sample: Import trace for requested module:
@logto/next-sample: ../js/lib/module.mjs
@logto/next-sample: ../client/lib/module.mjs
@logto/next-sample: ../node/lib/module.mjs
@logto/next-sample: ../next/lib/module.mjs
@logto/next-sample: ./libraries/logto.ts
@logto/next-sample: ../js/lib/module.mjs
```

The solution: https://github.com/firebase/firebase-js-sdk/issues/7002#issuecomment-1414526580

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
