### PR TITLE
fix: add node 22 to supported engines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v4
+        uses: silverhand-io/actions-node-pnpm-run-steps@v5
 
       - name: Lint
         run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": "^18.12.0 || ^20.9.0",
+    "node": "^18.12.0 || ^20.9.0 || ^22.0.0",
     "pnpm": "^9.0.0"
   },
   "prettier": "@silverhand/eslint-config/.prettierrc",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add node 22 to supported engine list. (fixes https://github.com/logto-io/js/issues/800)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
