### PR TITLE
chore: relax node engine range and bump version to 2.9.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18', '20', '22', '24', '25']
 
     steps:
       - uses: actions/checkout@v4
@@ -17,7 +21,7 @@ jobs:
         uses: silverhand-io/actions-node-pnpm-run-steps@v5
         with:
           pnpm-version: '10'
-          node-version: '24'
+          node-version: ${{ matrix.node-version }}
 
       - name: Lint
         run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silverhand/essentials",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "The missing essentials for TypeScript (and JavaScript).",
   "repository": "git@github.com:silverhand-io/essentials.git",
   "author": "Silverhand Inc.",
@@ -43,7 +43,7 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": "^18.12.0 || ^20.9.0 || ^22.0.0 || ^24.0.0",
+    "node": ">=18.12.0",
     "pnpm": "^10.0.0"
   },
   "prettier": "@silverhand/eslint-config/.prettierrc",


### PR DESCRIPTION
## Summary
- Relax the Node.js engine requirement to >=18.12.0.
- Bump package version to 2.9.3.
- Expand CI coverage to a Node.js matrix: 18, 20, 22, 24 and 25.

## Linear Issue Reference
- N/A

## Testing
- CI workflow now runs Lint, Test, Build, and CommonJS smoke test across Node 18/20/22/24.